### PR TITLE
Fix data response using correct hashmap structure

### DIFF
--- a/src/mobytronics/handler.clj
+++ b/src/mobytronics/handler.clj
@@ -17,7 +17,8 @@
 (def parse-link-data
   (fn [m]
     (if-let [link (get m :link)]
-      (concat m (parse-html-content (lookup-page link))))))
+      (into {}
+            (concat m (parse-html-content (lookup-page link)))))))
 
 (defn get-all-links
   "get all data into a hash-map"


### PR DESCRIPTION
This fix an issue with json data structure using correctly an hashmap instead of storing data into vectors.